### PR TITLE
 Change reference to tomv564's pyls-mypy to python-lsp/pylsp-mypy

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -105,7 +105,7 @@ class PythonLanguageClient extends AutoLanguageClient {
           "Make sure to install `pylsp` 0.19 or newer by running:\n" +
           "```\n" +
           `${this.python} -m pip install 'python-lsp-server[all]'\n` +
-          `${this.python} -m pip install git+https://github.com/tomv564/pyls-mypy.git\n` +
+          `${this.python} -m pip install 'pylsp-mypy'\n` +
           "```",
       })
     }


### PR DESCRIPTION
Hi there,

When getting the error message from this package about the Language Servers not being installed, I found that one of the links is very outdated and links to a version of pyls(p)-mypy that has broken code.

Python-LSP's "pylsp-mypy" is a very well-updated fork of tomv564's "pyls-mypy" and it's on PyPi.

tomv564's pyls-mypy has an outdated versioneer.py which contains a bad reference to configparser.SafeConfigParser instead of ConfigParser. 

see https://github.com/Matoking/python-ed25519-blake2b/commit/bbc52046755dff306100b03609ff14b27e490277 for what the correct fix would be, but tomv564's old original fork is so old and not updated.

Better have a pip command for the new python-lsp/pylsp package that's very actively updated, then we don't get this ugly error when following the directioins from pulsar-ide-python package.

```python
Resolved https://github.com/tomv564/pyls-mypy.git to commit 3b105b491a42eec304f19e6ed6da1053d12958c6
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [31 lines of output]
      /tmp/pip-install-k2s1him4/pyls-mypy_e38b58a674f34a8981d026c66580bd10/versioneer.py:421: SyntaxWarning: invalid escape sequence '\s'
        LONG_VERSION_PY['git'] = '''
      Traceback (most recent call last):
        File "/home/cat/Sync/projects/git/mw/.venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/cat/Sync/projects/git/mw/.venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/cat/Sync/projects/git/mw/.venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-6weuvjrf/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 332, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-6weuvjrf/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 302, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-6weuvjrf/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 503, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-6weuvjrf/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 318, in run_setup
          exec(code, locals())
        File "<string>", line 6, in <module>
        File "/tmp/pip-install-k2s1him4/pyls-mypy_e38b58a674f34a8981d026c66580bd10/versioneer.py", line 1480, in get_version
          return get_versions()["version"]
                 ^^^^^^^^^^^^^^
        File "/tmp/pip-install-k2s1him4/pyls-mypy_e38b58a674f34a8981d026c66580bd10/versioneer.py", line 1412, in get_versions
          cfg = get_config_from_root(root)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-install-k2s1him4/pyls-mypy_e38b58a674f34a8981d026c66580bd10/versioneer.py", line 342, in get_config_from_root
          parser = configparser.SafeConfigParser()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      AttributeError: module 'configparser' has no attribute 'SafeConfigParser'. Did you mean: 'RawConfigParser'?
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error
```