### PR TITLE
Hook up two services, including `symbol.provider` (for go-to-definition)

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -13,6 +13,10 @@ class PythonLanguageClient extends AutoLanguageClient {
     atom.config.unset("pulsar-ide-python.pylsPath")
   }
 
+  getPackageName() {
+    return this.getRootConfigurationKey()
+  }
+
   /* eslint-disable class-methods-use-this */
   getGrammarScopes() {
     return ["source.python", "python"]

--- a/package.json
+++ b/package.json
@@ -696,6 +696,11 @@
         "0.1.0": "provideFindReferences"
       }
     },
+    "intentions:list": {
+      "versions": {
+        "1.0.0": "provideIntentionsList"
+      }
+    },
     "outline-view": {
       "versions": {
         "0.1.0": "provideOutlines"
@@ -705,6 +710,11 @@
       "versions": {
         "0.1.0": "provideRefactor",
         "0.2.0": "provideRefactorWithPrepare"
+      }
+    },
+    "symbol.provider": {
+      "versions": {
+        "1.0.0": "provideSymbols"
       }
     }
   }


### PR DESCRIPTION
I noticed there were a couple of services that weren't hooked up.

The first, `symbol.provider`, is pretty crucial — it's what makes **Symbols View: Go To Declaration** possible. It also allows for project-wide symbol search (though `pyls` may not implement the underlying method for that) and acts as a provider for **Symbols View: Toggle File Symbols**. (The latter returns a lot more stuff than other symbol providers, but you could override the `shouldIgnoreSymbol` method on `AutoLanguageClient` if you wanted to filter out things like imports and variable assignments. Happy to add that to this PR if you'd like.)

The other is `intentions:show`, which is provided by the [intentions](https://web.pulsar-edit.dev/packages/intentions) package. I hooked this up as part of my `atom-languageclient` changes because it's a widely installed package that can do the same sort of stuff as `atom-ide-code-actions` without all the Nuclide baggage. It's wired up to show both code actions and possible linting fixes when **Intentions: Show** is invoked.

It doesn't seem to do anything in my tests, but that's not unusual. It's still good to wire that up just in case the language server itself starts implementing more stuff.